### PR TITLE
Implementation of sample streaming mode

### DIFF
--- a/dialout/dialout_client/dialout_client_test.go
+++ b/dialout/dialout_client/dialout_client_test.go
@@ -6,7 +6,10 @@ package telemetry_dialout
 import (
 	"crypto/tls"
 	"encoding/json"
+	"flag"
+
 	"github.com/go-redis/redis"
+
 	//"github.com/golang/protobuf/proto"
 	testcert "github.com/Azure/sonic-telemetry/testdata/tls"
 
@@ -16,6 +19,7 @@ import (
 	"github.com/openconfig/gnmi/value"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	//"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	//"google.golang.org/grpc/status"
@@ -503,6 +507,10 @@ func TestGNMIDialOutPublish(t *testing.T) {
 }
 
 func init() {
+	// Enable logs at UT setup
+	flag.Lookup("v").Value.Set("10")
+	flag.Lookup("log_dir").Value.Set("/tmp/telemetrytest")
+
 	// Inform gNMI server to use redis tcp localhost connection
 	sdc.UseRedisLocalTcpPort = true
 }

--- a/gnmi_server/client_subscribe.go
+++ b/gnmi_server/client_subscribe.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/golang/glog"
 	"github.com/Workiva/go-datastructures/queue"
+	log "github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -118,19 +118,18 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	}
 	var dc sdc.Client
 
-    if target == "OTHERS" {
-            dc, err = sdc.NewNonDbClient(paths, prefix)
-    } else if isTargetDb(target) == true {
-            dc, err = sdc.NewDbClient(paths, prefix)
-    } else {
-            /* For any other target or no target create new Transl Client. */
-            dc, err = sdc.NewTranslClient(prefix, paths)
-    }
+	if target == "OTHERS" {
+		dc, err = sdc.NewNonDbClient(paths, prefix)
+	} else if isTargetDb(target) == true {
+		dc, err = sdc.NewDbClient(paths, prefix)
+	} else {
+		/* For any other target or no target create new Transl Client. */
+		dc, err = sdc.NewTranslClient(prefix, paths)
+	}
 
-    if err != nil {
-            return grpc.Errorf(codes.NotFound, "%v", err)
-    }
-
+	if err != nil {
+		return grpc.Errorf(codes.NotFound, "%v", err)
+	}
 
 	switch mode := c.subscribe.GetMode(); mode {
 	case gnmipb.SubscriptionList_STREAM:
@@ -154,6 +153,7 @@ func (c *Client) Run(stream gnmipb.GNMI_SubscribeServer) (err error) {
 	log.V(1).Infof("Client %s running", c)
 	go c.recv(stream)
 	err = c.send(stream)
+
 	c.Close()
 	// Wait until all child go routines exited
 	c.w.Wait()
@@ -189,6 +189,7 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 
 	for {
 		log.V(5).Infof("Client %s blocking on stream.Recv()", c)
+
 		event, err := stream.Recv()
 		c.recvMsg++
 
@@ -198,6 +199,17 @@ func (c *Client) recv(stream gnmipb.GNMI_SubscribeServer) {
 			return
 		case io.EOF:
 			log.V(1).Infof("Client %s received io.EOF", c)
+
+			if c.subscribe.Mode == gnmipb.SubscriptionList_STREAM {
+				// The client->server could be closed after the sending the subscription list.
+				// EOF is not a indication of client is not listening.
+				// Instead stream.Context() which is signaled once the underlying connection is terminated.
+				log.V(1).Infof("Waiting for client '%s'", c)
+				// This context is done when the client connection is terminated.
+				<-stream.Context().Done()
+				log.V(1).Infof("Client is done '%s'", c)
+			}
+
 			return
 		case nil:
 		}

--- a/gnmi_server/server_test.go
+++ b/gnmi_server/server_test.go
@@ -6,30 +6,37 @@ package gnmi
 import (
 	"crypto/tls"
 	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+
 	testcert "github.com/Azure/sonic-telemetry/testdata/tls"
 	"github.com/go-redis/redis"
 	"github.com/golang/protobuf/proto"
 
-	"github.com/kylelemons/godebug/pretty"
-	"github.com/openconfig/gnmi/client"
-	pb "github.com/openconfig/gnmi/proto/gnmi"
-	"github.com/openconfig/gnmi/value"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/status"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/gnmi/client"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmi/value"
+	"github.com/openconfig/ygot/ygot"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
 	// Register supported client types.
 	sdc "github.com/Azure/sonic-telemetry/sonic_data_client"
 	sdcfg "github.com/Azure/sonic-telemetry/sonic_db_config"
 	gclient "github.com/jipanyang/gnmi/client/gnmi"
-
 )
 
 var clientTypes = []string{gclient.Type}
@@ -121,7 +128,7 @@ func runTestGet(t *testing.T, ctx context.Context, gClient pb.GNMIClient, pathTa
 		t.Log("err: ", err)
 		t.Fatalf("got return code %v, want %v", gotRetStatus.Code(), wantRetCode)
 	}
-	
+
 	// Check response value
 	if valTest {
 		var gotVal interface{}
@@ -389,7 +396,7 @@ func prepareDbTranslib(t *testing.T) {
 	rclient := getRedisClient(t)
 	rclient.FlushDB()
 	rclient.Close()
-	
+
 	//Enable keysapce notification
 	os.Setenv("PATH", "/usr/bin:/sbin:/bin:/usr/local/bin")
 	cmd := exec.Command("redis-cli", "config", "set", "notify-keyspace-events", "KEA")
@@ -410,6 +417,167 @@ func prepareDbTranslib(t *testing.T) {
 		loadDBNotStrict(t, rclient, v)
 		rclient.Close()
 	}
+}
+
+// subscriptionQuery represent the input to create an gnmi.Subscription instance.
+type subscriptionQuery struct {
+	Query          []string
+	SubMode        pb.SubscriptionMode
+	SampleInterval uint64
+}
+
+func pathToString(q client.Path) string {
+	qq := make(client.Path, len(q))
+	copy(qq, q)
+	// Escape all slashes within a path element. ygot.StringToPath will handle
+	// these escapes.
+	for i, e := range qq {
+		qq[i] = strings.Replace(e, "/", "\\/", -1)
+	}
+	return strings.Join(qq, "/")
+}
+
+// createQuery creates a client.Query with the given args. It assigns query.SubReq.
+func createQuery(subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery, updatesOnly bool) (*client.Query, error) {
+	s := &pb.SubscribeRequest_Subscribe{
+		Subscribe: &pb.SubscriptionList{
+			Mode:   subListMode,
+			Prefix: &pb.Path{Target: target},
+		},
+	}
+	if updatesOnly {
+		s.Subscribe.UpdatesOnly = true
+	}
+
+	for _, qq := range queries {
+		pp, err := ygot.StringToPath(pathToString(qq.Query), ygot.StructuredPath, ygot.StringSlicePath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid query path %q: %v", qq, err)
+		}
+		s.Subscribe.Subscription = append(
+			s.Subscribe.Subscription,
+			&pb.Subscription{
+				Path:           pp,
+				Mode:           qq.SubMode,
+				SampleInterval: qq.SampleInterval,
+			})
+	}
+
+	subReq := &pb.SubscribeRequest{Request: s}
+	query, err := client.NewQuery(subReq)
+	query.TLS = &tls.Config{InsecureSkipVerify: true}
+	return &query, err
+}
+
+// createQueryOrFail creates a query, in case of a failure it fails the test.
+func createQueryOrFail(t *testing.T, subListMode pb.SubscriptionList_Mode, target string, queries []subscriptionQuery, updatesOnly bool) client.Query {
+	q, err := createQuery(subListMode, target, queries, updatesOnly)
+	if err != nil {
+		t.Fatalf("failed to create query: %v", err)
+	}
+
+	return *q
+}
+
+// createCountersDbQueryOnChangeMode creates a query with ON_CHANGE mode.
+func createCountersDbQueryOnChangeMode(t *testing.T, paths ...string) client.Query {
+	return createQueryOrFail(t,
+		pb.SubscriptionList_STREAM,
+		"COUNTERS_DB",
+		[]subscriptionQuery{
+			{
+				Query:   paths,
+				SubMode: pb.SubscriptionMode_ON_CHANGE,
+			},
+		},
+		false)
+}
+
+// createCountersDbQuerySampleMode creates a query with SAMPLE mode.
+func createCountersDbQuerySampleMode(t *testing.T, interval time.Duration, updateOnly bool, paths ...string) client.Query {
+	return createQueryOrFail(t,
+		pb.SubscriptionList_STREAM,
+		"COUNTERS_DB",
+		[]subscriptionQuery{
+			{
+				Query:          paths,
+				SubMode:        pb.SubscriptionMode_SAMPLE,
+				SampleInterval: uint64(interval.Nanoseconds()),
+			},
+		},
+		updateOnly)
+}
+
+// createCountersTableSetUpdate creates a HSET request on the COUNTERS table.
+func createCountersTableSetUpdate(tableKey string, fieldName string, fieldValue string) tablePathValue {
+	return tablePathValue{
+		dbName:    "COUNTERS_DB",
+		tableName: "COUNTERS",
+		tableKey:  tableKey,
+		delimitor: ":",
+		field:     fieldName,
+		value:     fieldValue,
+	}
+}
+
+// createCountersTableDeleteUpdate creates a DEL request on the COUNTERS table.
+func createCountersTableDeleteUpdate(tableKey string, fieldName string) tablePathValue {
+	return tablePathValue{
+		dbName:    "COUNTERS_DB",
+		tableName: "COUNTERS",
+		tableKey:  tableKey,
+		delimitor: ":",
+		field:     fieldName,
+		value:     "",
+		op:        "hdel",
+	}
+}
+
+// createIntervalTickerUpdate creates a request for triggering the interval clock.
+func createIntervalTickerUpdate() tablePathValue {
+	return tablePathValue{
+		op: "intervaltick",
+	}
+}
+
+// cloneObject clones a given object via JSON serialize/deserialize
+func cloneObject(obj interface{}) interface{} {
+	objData, err := json.Marshal(obj)
+	if err != nil {
+		panic(fmt.Errorf("marshal failed, %v", err))
+	}
+
+	var cloneObj interface{}
+	err = json.Unmarshal(objData, &cloneObj)
+	if err != nil {
+		panic(fmt.Errorf("unmarshal failed, %v", err))
+	}
+
+	return cloneObj
+}
+
+// mergeStrMaps merges given maps where they are keyed with string.
+func mergeStrMaps(sourceOrigin interface{}, updateOrigin interface{}) interface{} {
+	// Clone the maps so that the originals are not changed during the merge.
+	source := cloneObject(sourceOrigin)
+	update := cloneObject(updateOrigin)
+
+	// Check if both are string keyed maps
+	sourceStrMap, okSrcMap := source.(map[string]interface{})
+	updateStrMap, okUpdateMap := update.(map[string]interface{})
+	if okSrcMap && okUpdateMap {
+		for itemKey, updateItem := range updateStrMap {
+			sourceItem, sourceItemOk := sourceStrMap[itemKey]
+			if sourceItemOk {
+				sourceStrMap[itemKey] = updateItem
+			} else {
+				sourceStrMap[itemKey] = mergeStrMaps(sourceItem, updateItem)
+			}
+		}
+		return sourceStrMap
+	}
+
+	return update
 }
 
 func TestGnmiSet(t *testing.T) {
@@ -511,8 +679,6 @@ func TestGnmiSet(t *testing.T) {
 	}
 	s.s.Stop()
 }
-
-
 
 func TestGnmiGet(t *testing.T) {
 	//t.Log("Start server")
@@ -745,56 +911,56 @@ func TestGnmiGetTranslib(t *testing.T) {
 	}{
 
 		//These tests only work on the real switch platform, since they rely on files in the /proc and another running service
-	// 	{
-	// 	desc:       "Get OC Platform",
-	// 	pathTarget: "OC_YANG",
-	// 	textPbPath: `
- //                        elem: <name: "openconfig-platform:components" >
- //                `,
-	// 	wantRetCode: codes.OK,
-	// 	wantRespVal: emptyRespVal,
-	// 	valTest:     false,
-	// },
-	// 	{
-	// 		desc:       "Get OC System State",
-	// 		pathTarget: "OC_YANG",
-	// 		textPbPath: `
- //                        elem: <name: "openconfig-system:system" > elem: <name: "state" >
- //                `,
-	// 		wantRetCode: codes.OK,
-	// 		wantRespVal: emptyRespVal,
-	// 		valTest:     false,
-	// 	},
-	// 	{
-	// 		desc:       "Get OC System CPU",
-	// 		pathTarget: "OC_YANG",
-	// 		textPbPath: `
- //                        elem: <name: "openconfig-system:system" > elem: <name: "cpus" >
- //                `,
-	// 		wantRetCode: codes.OK,
-	// 		wantRespVal: emptyRespVal,
-	// 		valTest:     false,
-	// 	},
-	// 	{
-	// 		desc:       "Get OC System memory",
-	// 		pathTarget: "OC_YANG",
-	// 		textPbPath: `
- //                        elem: <name: "openconfig-system:system" > elem: <name: "memory" >
- //                `,
-	// 		wantRetCode: codes.OK,
-	// 		wantRespVal: emptyRespVal,
-	// 		valTest:     false,
-	// 	},
-	// 	{
-	// 		desc:       "Get OC System processes",
-	// 		pathTarget: "OC_YANG",
-	// 		textPbPath: `
- //                        elem: <name: "openconfig-system:system" > elem: <name: "processes" >
- //                `,
-	// 		wantRetCode: codes.OK,
-	// 		wantRespVal: emptyRespVal,
-	// 		valTest:     false,
-	// 	},
+		// 	{
+		// 	desc:       "Get OC Platform",
+		// 	pathTarget: "OC_YANG",
+		// 	textPbPath: `
+		//                        elem: <name: "openconfig-platform:components" >
+		//                `,
+		// 	wantRetCode: codes.OK,
+		// 	wantRespVal: emptyRespVal,
+		// 	valTest:     false,
+		// },
+		// 	{
+		// 		desc:       "Get OC System State",
+		// 		pathTarget: "OC_YANG",
+		// 		textPbPath: `
+		//                        elem: <name: "openconfig-system:system" > elem: <name: "state" >
+		//                `,
+		// 		wantRetCode: codes.OK,
+		// 		wantRespVal: emptyRespVal,
+		// 		valTest:     false,
+		// 	},
+		// 	{
+		// 		desc:       "Get OC System CPU",
+		// 		pathTarget: "OC_YANG",
+		// 		textPbPath: `
+		//                        elem: <name: "openconfig-system:system" > elem: <name: "cpus" >
+		//                `,
+		// 		wantRetCode: codes.OK,
+		// 		wantRespVal: emptyRespVal,
+		// 		valTest:     false,
+		// 	},
+		// 	{
+		// 		desc:       "Get OC System memory",
+		// 		pathTarget: "OC_YANG",
+		// 		textPbPath: `
+		//                        elem: <name: "openconfig-system:system" > elem: <name: "memory" >
+		//                `,
+		// 		wantRetCode: codes.OK,
+		// 		wantRespVal: emptyRespVal,
+		// 		valTest:     false,
+		// 	},
+		// 	{
+		// 		desc:       "Get OC System processes",
+		// 		pathTarget: "OC_YANG",
+		// 		textPbPath: `
+		//                        elem: <name: "openconfig-system:system" > elem: <name: "processes" >
+		//                `,
+		// 		wantRetCode: codes.OK,
+		// 		wantRespVal: emptyRespVal,
+		// 		valTest:     false,
+		// 	},
 		{
 			desc:       "Get OC Interfaces",
 			pathTarget: "OC_YANG",
@@ -1023,288 +1189,272 @@ func runTestSubscribe(t *testing.T) {
 	countersEthernet68QueuesAliasJsonUpdate["Ethernet68/1:1"] = eth68_1
 
 	tests := []struct {
-		desc     string
-		q        client.Query
-		prepares []tablePathValue
-		updates  []tablePathValue
-		wantErr  bool
-		wantNoti []client.Notification
+		desc       string
+		q          client.Query
+		prepares   []tablePathValue
+		updates    []tablePathValue
+		wantErr    bool
+		wantNoti   []client.Notification
+		wantSubErr error
 
 		poll        int
 		wantPollErr string
-	}{{
-		desc: "stream query for table COUNTERS_PORT_NAME_MAP with new test_field field",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS_PORT_NAME_MAP"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
+
+		generateIntervals bool
+	}{
+		{
+			desc: "stream query for table COUNTERS_PORT_NAME_MAP with new test_field field",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS_PORT_NAME_MAP"),
+			updates: []tablePathValue{{
+				dbName:    "COUNTERS_DB",
+				tableName: "COUNTERS_PORT_NAME_MAP",
+				field:     "test_field",
+				value:     "test_value",
+			}},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJsonUpdate},
+			},
 		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS_PORT_NAME_MAP",
-			field:     "test_field",
-			value:     "test_value",
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJson},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJsonUpdate},
+		{
+			desc: "stream query for table key Ethernet68 with new test_field field",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+			},
 		},
-	}, {
-		desc: "stream query for table key Ethernet68 with new test_field field",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
+		{
+			desc: "(use vendor alias) stream query for table key Ethernet68/1 with new test_field field",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68/1"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+			},
 		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "test_field",
-			value:     "test_value",
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "test_field",
-			value:     "test_value",
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+		{
+			desc: "stream query for COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS with update of field value",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "3", // be changed to 3 from 2
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "3", // be changed to 3 from 2
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
+			},
 		},
-	}, {
-		desc: "(use vendor alias) stream query for table key Ethernet68/1 with new test_field field",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68/1"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
+		{
+			desc: "(use vendor alias) stream query for COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS with update of field value",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "3", // be changed to 3 from 2
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "3", // be changed to 3 from 2
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
+			},
 		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "test_field",
-			value:     "test_value",
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "test_field",
-			value:     "test_value",
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+		{
+			desc: "stream query for COUNTERS/Ethernet68/Pfcwd with update of field value",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68", "Pfcwd"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 0
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e"
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 1
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJsonUpdate},
+			},
 		},
-	}, {
-		desc: "stream query for COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS with update of field value",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
+		{
+			desc: "(use vendor alias) stream query for COUNTERS/[Ethernet68/1]/Pfcwd with update of field value",
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet68/1", "Pfcwd"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 0
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e"
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 1
+				},
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJsonUpdate},
+			},
 		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-			value:     "3", // be changed to 3 from 2
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-			value:     "3", // be changed to 3 from 2
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
-		},
-	}, {
-		desc: "(use vendor alias) stream query for COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS with update of field value",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
-		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-			value:     "3", // be changed to 3 from 2
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-			delimitor: ":",
-			field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-			value:     "3", // be changed to 3 from 2
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
-		},
-	}, {
-		desc: "stream query for COUNTERS/Ethernet68/Pfcwd with update of field value",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68", "Pfcwd"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
-		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-			delimitor: ":",
-			field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-			value:     "1", // be changed to 1 from 0
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e"
-			delimitor: ":",
-			field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-			value:     "1", // be changed to 1 from 1
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJson},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJsonUpdate},
-		},
-	}, {
-		desc: "(use vendor alias) stream query for COUNTERS/[Ethernet68/1]/Pfcwd with update of field value",
-		q: client.Query{
-			Target:  "COUNTERS_DB",
-			Type:    client.Stream,
-			Queries: []client.Path{{"COUNTERS", "Ethernet68/1", "Pfcwd"}},
-			TLS:     &tls.Config{InsecureSkipVerify: true},
-		},
-		updates: []tablePathValue{{
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-			delimitor: ":",
-			field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-			value:     "1", // be changed to 1 from 0
-		}, { //Same value set should not trigger multiple updates
-			dbName:    "COUNTERS_DB",
-			tableName: "COUNTERS",
-			tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e"
-			delimitor: ":",
-			field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-			value:     "1", // be changed to 1 from 1
-		}},
-		wantNoti: []client.Notification{
-			client.Connected{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJson},
-			client.Sync{},
-			client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJsonUpdate},
-		},
-	},
 		{
 			desc: "stream query for table key Ethernet* with new test_field field on Ethernet68",
-			q: client.Query{
-				Target:  "COUNTERS_DB",
-				Type:    client.Stream,
-				Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
-				TLS:     &tls.Config{InsecureSkipVerify: true},
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
+				{ //Same value set should not trigger multiple updates
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "test_field",
+					value:     "test_value",
+				},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "test_field",
-				value:     "test_value",
-			}, { //Same value set should not trigger multiple updates
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "test_field",
-				value:     "test_value",
-			}},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
 			},
-		}, {
+		},
+		{
 			desc: "stream query for table key Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS with field value update",
-			q: client.Query{
-				Target:  "COUNTERS_DB",
-				Type:    client.Stream,
-				Queries: []client.Path{{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
-				TLS:     &tls.Config{InsecureSkipVerify: true},
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "4", // being changed to 4 from 2
+				},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-				value:     "4", // being changed to 4 from 2
-			}},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: singlePortPfcJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: singlePortPfcJsonUpdate},
 			},
-		}, {
+		},
+		{
 			desc: "stream query for table key Ethernet*/Pfcwd with field value update",
-			q: client.Query{
-				Target:  "COUNTERS_DB",
-				Type:    client.Stream,
-				Queries: []client.Path{{"COUNTERS", "Ethernet*", "Pfcwd"}},
-				TLS:     &tls.Config{InsecureSkipVerify: true},
+			q:    createCountersDbQueryOnChangeMode(t, "COUNTERS", "Ethernet*", "Pfcwd"),
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // being changed to 1 from 0
+				},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-				delimitor: ":",
-				field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-				value:     "1", // being changed to 1 from 0
-			}},
 			wantNoti: []client.Notification{
 				client.Connected{},
 				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernetWildPfcwdJson},
 				client.Sync{},
 				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJsonUpdate},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for table COUNTERS_PORT_NAME_MAP with new field test_field",
 			poll: 3,
 			q: client.Query{
@@ -1331,7 +1481,8 @@ func runTestSubscribe(t *testing.T) {
 				client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJsonUpdate},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for table COUNTERS_PORT_NAME_MAP with test_field delete",
 			poll: 3,
 			q: client.Query{
@@ -1340,18 +1491,22 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS_PORT_NAME_MAP"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			prepares: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS_PORT_NAME_MAP",
-				field:     "test_field",
-				value:     "test_value",
-			}},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS_PORT_NAME_MAP",
-				field:     "test_field",
-				op:        "hdel",
-			}},
+			prepares: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS_PORT_NAME_MAP",
+					field:     "test_field",
+					value:     "test_value",
+				},
+			},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS_PORT_NAME_MAP",
+					field:     "test_field",
+					op:        "hdel",
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
 				// We are starting from the result data of "stream query for table with update of new field",
@@ -1364,7 +1519,8 @@ func runTestSubscribe(t *testing.T) {
 				client.Update{Path: []string{"COUNTERS_PORT_NAME_MAP"}, TS: time.Unix(0, 200), Val: countersPortNameMapJson},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1373,30 +1529,29 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-				value:     "4", // being changed to 4 from 2
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "4", // being changed to 4 from 2
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "2"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "(use vendor alias) poll query for COUNTERS/[Ethernet68/1]/SAI_PORT_STAT_PFC_7_RX_PKTS with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1405,30 +1560,29 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-				value:     "4", // being changed to 4 from 2
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "4", // being changed to 4 from 2
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "2"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: "4"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "4"},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for COUNTERS/Ethernet68/Pfcwd with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1437,14 +1591,16 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68", "Pfcwd"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-				delimitor: ":",
-				field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-				value:     "1", // be changed to 1 from 0
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 0
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
 				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJson},
@@ -1456,7 +1612,8 @@ func runTestSubscribe(t *testing.T) {
 				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdPollUpdate},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "(use vendor alias) poll query for COUNTERS/[Ethernet68/1]/Pfcwd with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1465,14 +1622,16 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68/1", "Pfcwd"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-				delimitor: ":",
-				field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-				value:     "1", // be changed to 1 from 0
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // be changed to 1 from 0
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
 				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJson},
@@ -1494,30 +1653,29 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet*"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-				value:     "4", // being changed to 4 from 2
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "4", // being changed to 4 from 2
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersFieldUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersFieldUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersFieldUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersFieldUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*"},
-					TS: time.Unix(0, 200), Val: countersFieldUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersFieldUpdate},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for table key field Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS with Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS field value change",
 			poll: 3,
 			q: client.Query{
@@ -1526,30 +1684,29 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
-				delimitor: ":",
-				field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
-				value:     "4", // being changed to 4 from 2
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1000000000039", // "Ethernet68": "oid:0x1000000000039",
+					delimitor: ":",
+					field:     "SAI_PORT_STAT_PFC_7_RX_PKTS",
+					value:     "4", // being changed to 4 from 2
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"},
-					TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: allPortPfcJsonUpdate},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for table key field Etherenet*/Pfcwd with Ethernet68:3/PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED field value change",
 			poll: 3,
 			q: client.Query{
@@ -1558,14 +1715,16 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet*", "Pfcwd"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
-				delimitor: ":",
-				field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
-				value:     "1", // being changed to 1 from 0
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091e", // "Ethernet68:3": "oid:0x1500000000091e",
+					delimitor: ":",
+					field:     "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED",
+					value:     "1", // being changed to 1 from 0
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
 				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernetWildPfcwdJson},
@@ -1589,14 +1748,13 @@ func runTestSubscribe(t *testing.T) {
 			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildQueuesJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernetWildQueuesJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernetWildQueuesJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernetWildQueuesJson},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "poll query for COUNTERS/Ethernet68/Queues with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1605,30 +1763,29 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68", "Queues"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091c", // "Ethernet68:1": "oid:0x1500000000091c",
-				delimitor: ":",
-				field:     "SAI_QUEUE_STAT_DROPPED_PACKETS",
-				value:     "4", // being changed to 0 from 4
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091c", // "Ethernet68:1": "oid:0x1500000000091c",
+					delimitor: ":",
+					field:     "SAI_QUEUE_STAT_DROPPED_PACKETS",
+					value:     "4", // being changed to 0 from 4
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesJsonUpdate},
 				client.Sync{},
 			},
-		}, {
+		},
+		{
 			desc: "(use vendor alias) poll query for COUNTERS/Ethernet68/Queues with field value change",
 			poll: 3,
 			q: client.Query{
@@ -1637,30 +1794,211 @@ func runTestSubscribe(t *testing.T) {
 				Queries: []client.Path{{"COUNTERS", "Ethernet68/1", "Queues"}},
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			},
-			updates: []tablePathValue{{
-				dbName:    "COUNTERS_DB",
-				tableName: "COUNTERS",
-				tableKey:  "oid:0x1500000000091c", // "Ethernet68:1": "oid:0x1500000000091c",
-				delimitor: ":",
-				field:     "SAI_QUEUE_STAT_DROPPED_PACKETS",
-				value:     "4", // being changed to 0 from 4
-			}},
+			updates: []tablePathValue{
+				{
+					dbName:    "COUNTERS_DB",
+					tableName: "COUNTERS",
+					tableKey:  "oid:0x1500000000091c", // "Ethernet68:1": "oid:0x1500000000091c",
+					delimitor: ":",
+					field:     "SAI_QUEUE_STAT_DROPPED_PACKETS",
+					value:     "4", // being changed to 0 from 4
+				},
+			},
 			wantNoti: []client.Notification{
 				client.Connected{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJson},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJson},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
 				client.Sync{},
-				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"},
-					TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Queues"}, TS: time.Unix(0, 200), Val: countersEthernet68QueuesAliasJsonUpdate},
 				client.Sync{},
 			},
-		}}
+		},
+		{
+			desc:       "use invalid sample interval",
+			q:          createCountersDbQuerySampleMode(t, 10*time.Millisecond, false, "COUNTERS", "Ethernet1"),
+			updates:    []tablePathValue{},
+			wantSubErr: fmt.Errorf("rpc error: code = InvalidArgument desc = invalid interval: 10ms. It cannot be less than %v", sdc.MinSampleInterval),
+			wantNoti:   []client.Notification{},
+		},
+		{
+			desc:              "sample stream query for table key Ethernet68 with new test_field field",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet68"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+			},
+		},
+		{
+			desc:              "sample stream query for COUNTERS/Ethernet68/SAI_PORT_STAT_PFC_7_RX_PKTS with 2 updates",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "SAI_PORT_STAT_PFC_7_RX_PKTS", "3"), // be changed to 3 from 2
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "2"},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: "3"},
+			},
+		},
+		{
+			desc:              "(use vendor alias) sample stream query for table key Ethernet68/1 with new test_field field",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet68/1"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68Json},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1"}, TS: time.Unix(0, 200), Val: countersEthernet68JsonUpdate},
+			},
+		},
+		{
+			desc:              "sample stream query for COUNTERS/Ethernet68/Pfcwd with update of field value",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet68", "Pfcwd"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1500000000091e", "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", "1"),
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernet68PfcwdJson, countersEthernet68PfcwdJsonUpdate)},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68", "Pfcwd"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernet68PfcwdJson, countersEthernet68PfcwdJsonUpdate)},
+			},
+		},
+		{
+			desc:              "(use vendor alias) sample stream query for COUNTERS/[Ethernet68/1]/Pfcwd with update of field value",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet68/1", "Pfcwd"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1500000000091e", "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", "1"),
+				createCountersTableSetUpdate("oid:0x1500000000091e", "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", "0"), // change back to 0
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernet68PfcwdAliasJson, countersEthernet68PfcwdAliasJsonUpdate)},
+				client.Update{Path: []string{"COUNTERS", "Ethernet68/1", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJson},
+			},
+		},
+		{
+			desc:              "sample stream query for table key Ethernet* with new test_field field on Ethernet68",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildcardJson, countersEtherneWildcardJsonUpdate)},
+			},
+		},
+		{
+			desc:              "(updates only) sample stream query for table key Ethernet* with new test_field field on Ethernet68",
+			q:                 createCountersDbQuerySampleMode(t, 0, true, "COUNTERS", "Ethernet*"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createIntervalTickerUpdate(), // no value change but imitate interval ticker
+				createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+				createIntervalTickerUpdate(),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEtherneWildcardJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+			},
+		},
+		/*
+			// deletion of field from table is not supported. It'd keep sending the last value before the deletion.
+				{
+					desc:              "sample stream query for table key Ethernet* with new test_field field deleted from Ethernet68",
+					q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*"),
+					generateIntervals: true,
+					updates: []tablePathValue{
+						createCountersTableSetUpdate("oid:0x1000000000039", "test_field", "test_value"),
+						createCountersTableDeleteUpdate("oid:0x1000000000039", "test_field"),
+					},
+					wantNoti: []client.Notification{
+						client.Connected{},
+						client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson},
+						client.Sync{},
+						client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildcardJson, countersEtherneWildcardJsonUpdate)},
+						client.Update{Path: []string{"COUNTERS", "Ethernet*"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardJson}, //go back to original after deletion of test_field
+					},
+				},
+		*/
+		{
+			desc:              "sample stream query for table key Ethernet*/SAI_PORT_STAT_PFC_7_RX_PKTS with field value update",
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"),
+			generateIntervals: true,
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1000000000039", "SAI_PORT_STAT_PFC_7_RX_PKTS", "4"),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: countersEthernetWildcardPfcJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "SAI_PORT_STAT_PFC_7_RX_PKTS"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildcardPfcJson, singlePortPfcJsonUpdate)},
+			},
+		},
+		{
+			desc:              "sample stream query for table key Ethernet*/Pfcwd with field value update",
+			generateIntervals: true,
+			q:                 createCountersDbQuerySampleMode(t, 0, false, "COUNTERS", "Ethernet*", "Pfcwd"),
+			updates: []tablePathValue{
+				createCountersTableSetUpdate("oid:0x1500000000091e", "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", "1"),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernetWildPfcwdJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: mergeStrMaps(countersEthernetWildPfcwdJson, countersEthernet68PfcwdAliasJsonUpdate)},
+			},
+		},
+		{
+			desc:              "(update only) sample stream query for table key Ethernet*/Pfcwd with field value update",
+			generateIntervals: true,
+			q:                 createCountersDbQuerySampleMode(t, 0, true, "COUNTERS", "Ethernet*", "Pfcwd"),
+			updates: []tablePathValue{
+				createIntervalTickerUpdate(),
+				createCountersTableSetUpdate("oid:0x1500000000091e", "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", "1"),
+				createIntervalTickerUpdate(),
+			},
+			wantNoti: []client.Notification{
+				client.Connected{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernetWildPfcwdJson},
+				client.Sync{},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: countersEthernet68PfcwdAliasJsonUpdate},
+				client.Update{Path: []string{"COUNTERS", "Ethernet*", "Pfcwd"}, TS: time.Unix(0, 200), Val: map[string]interface{}{}}, //empty update
+			},
+		},
+	}
 
 	rclient := getRedisClient(t)
 	defer rclient.Close()
@@ -1675,6 +2013,14 @@ func runTestSubscribe(t *testing.T) {
 				rclient.HSet(prepare.tableName+prepare.delimitor+prepare.tableKey, prepare.field, prepare.value)
 			}
 		}
+
+		intervalTickerChan := make(chan time.Time)
+		if tt.generateIntervals {
+			sdc.IntervalTicker = func(interval time.Duration) <-chan time.Time {
+				return intervalTickerChan
+			}
+		}
+
 		time.Sleep(time.Millisecond * 1000)
 		t.Run(tt.desc, func(t *testing.T) {
 			q := tt.q
@@ -1683,7 +2029,6 @@ func runTestSubscribe(t *testing.T) {
 			defer c.Close()
 			var gotNoti []client.Notification
 			q.NotificationHandler = func(n client.Notification) error {
-				//t.Logf("reflect.TypeOf(n) %v :  %v", reflect.TypeOf(n), n)
 				if nn, ok := n.(client.Update); ok {
 					nn.TS = time.Unix(0, 200)
 					gotNoti = append(gotNoti, nn)
@@ -1694,7 +2039,10 @@ func runTestSubscribe(t *testing.T) {
 				return nil
 			}
 			go func() {
-				c.Subscribe(context.Background(), q)
+				err := c.Subscribe(context.Background(), q)
+				if tt.wantSubErr != nil && tt.wantSubErr.Error() != err.Error() {
+					t.Errorf("c.Subscribe expected %v, got %v", tt.wantSubErr, err)
+				}
 				/*
 					err := c.Subscribe(context.Background(), q)
 					t.Log("c.Subscribe err:", err)
@@ -1714,10 +2062,17 @@ func runTestSubscribe(t *testing.T) {
 				switch update.op {
 				case "hdel":
 					rclient.HDel(update.tableName+update.delimitor+update.tableKey, update.field)
+				case "intervaltick":
+					// This is not a DB update but a request to trigger sample interval
 				default:
 					rclient.HSet(update.tableName+update.delimitor+update.tableKey, update.field, update.value)
 				}
+
 				time.Sleep(time.Millisecond * 1000)
+
+				if tt.generateIntervals {
+					intervalTickerChan <- time.Now()
+				}
 			}
 			// wait for half second for change to sync
 			time.Sleep(time.Millisecond * 500)
@@ -1788,6 +2143,10 @@ func TestCapabilities(t *testing.T) {
 }
 
 func init() {
+	// Enable logs at UT setup
+	flag.Lookup("v").Value.Set("10")
+	flag.Lookup("log_dir").Value.Set("/tmp/telemetrytest")
+
 	// Inform gNMI server to use redis tcp localhost connection
 	sdc.UseRedisLocalTcpPort = true
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/openconfig/goyang v0.0.0-20200309174518-a00bece872fc // indirect
 	github.com/openconfig/ygot v0.7.1
 	github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 // indirect
+	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-redis/redis v6.15.6+incompatible h1:H9evprGPLI8+ci7fxQx6WNZHJSb7be8FqJQRhdQZ5Sg=
 github.com/go-redis/redis v6.15.6+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476 h1:WNSiFp8Ww4ZP7XUzW56zDYv5roKQ4VfsdHCLoh8oDj4=
 github.com/go-redis/redis/v7 v7.0.0-beta.3.0.20190824101152-d19aba07b476/go.mod h1:xhhSbUMTsleRPur+Vgx9sUHtyN33bdjxY+9/0n9Ig8s=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -85,6 +86,8 @@ github.com/openconfig/ygot v0.7.1 h1:kqDRYQpowXTr7EhGwr2BBDKJzqs+H8aFYjffYQ8lBsw
 github.com/openconfig/ygot v0.7.1/go.mod h1:5MwNX6DMP1QMf2eQjW+aJN/KNslVqRJtbfSL3SO6Urk=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 h1:YtFkrqsMEj7YqpIhRteVxJxCeC3jJBieuLr0d4C4rSA=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f h1:WyCn68lTiytVSkk7W1K9nBiSGTSRlUOdyTnSjwrIlok=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f/go.mod h1:/iRjX3DdSK956SzsUdV55J+wIsQ+2IBWmBrB4RvZfk4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/sonic_data_client/db_client.go
+++ b/sonic_data_client/db_client.go
@@ -167,7 +167,7 @@ func (c *DbClient) StreamRun(q *queue.PriorityQueue, stop chan struct{}, w *sync
 		log.V(2).Infof("Sub mode: %v, path: %v", sub.GetMode(), sub.GetPath())
 		subMode := sub.GetMode()
 
-		log.V(2).Infof("%s mode subscription selected, %v", sub.GetPath())
+		log.V(2).Infof("%s mode subscription selected, %v", subMode, sub.GetPath())
 
 		if subMode == gnmipb.SubscriptionMode_SAMPLE {
 			c.w.Add(1)


### PR DESCRIPTION
### DON'T REVIEW THIS PR, IT'S MOVED HERE: https://github.com/Azure/sonic-telemetry/pull/49

Implementation of sample streaming mode. The UT part is under progress and it will be separate iteration.

For testing results, see the example queries and the response:
- Virtual DB Single table:
```
./gnmi_cli_py/py_gnmicli.py -g -t localhost -p 8080 -m subscribe --submode 2 -x "COUNTERS/Ethernet0"   -xt COUNTERS_DB -o "ndastreamingservertest" --interval 5000 --update_count 3
```
Response: [single-table.txt](https://github.com/macikgozwa/sonic-telemetry/files/5521689/single-table.txt)

- Virtual DB Multiple table:

```
./gnmi_cli_py/py_gnmicli.py -g -t localhost -p 8080 -m subscribe --submode 2 -x "COUNTERS/Ethernet*"   -xt COUNTERS_DB -o "ndastreamingservertest" --interval 5000 --update_count 3
```
Response: [multi-table.txt](https://github.com/macikgozwa/sonic-telemetry/files/5521711/multi-table.txt)

- Single field
```
./gnmi_cli_py/py_gnmicli.py -g -t localhost -p 8080 -m subscribe --submode 2 -x "COUNTERS/Ethernet0/SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS"   -xt COUNTERS_DB -o "ndastreamingservertest" --interval 5000 --update_count 3
```
Response: [single-field.txt](https://github.com/macikgozwa/sonic-telemetry/files/5521717/single-field.txt)

- Single field across multiple tables
```
./gnmi_cli_py/py_gnmicli.py -g -t localhost -p 8080 -m subscribe --submode 2 -x "COUNTERS/Ethernet*/SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS"   -xt COUNTERS_DB -o "ndastreamingservertest" --interval 5000 --update_count 3 
```
Response: [multi-field.txt](https://github.com/macikgozwa/sonic-telemetry/files/5521720/multi-field.txt)




